### PR TITLE
(PE-29275) Add initial_fact_timeout parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,11 @@
 # @param apt_autoremove [Boolean]
 #   Should `apt-get autoremove` be run during reboot?
 #
+# @param initial_fact_timeout [Integer]
+#   How long in seconds to allow the command that collects patch information to run before
+#   timing out.  This only affects the initial run, not the cron/scheduled job.
+#   Timeout can be disabled by setting a value of 0.
+#
 # @param manage_delta_rpm [Boolean]
 #   Should the deltarpm package be managed by this module on RedHat family nodes?
 #   If `true`, use the parameter `delta_rpm` to determine how it should be manged
@@ -133,6 +138,7 @@ class pe_patch (
   Boolean $fact_upload                = true,
   Boolean $block_patching_on_warnings = false,
   Boolean $apt_autoremove             = false,
+  Integer $initial_fact_timeout       = 900,
   Enum['installed', 'absent', 'purged', 'held', 'latest'] $yum_utils = 'installed',
   Enum['installed', 'absent', 'purged', 'held', 'latest'] $delta_rpm = 'installed',
   Enum['installed', 'absent', 'purged', 'held', 'latest'] $yum_plugin_security = 'installed',
@@ -346,6 +352,7 @@ class pe_patch (
               File[$fact_cmd],
               File["${cache_dir}/reboot_override"]
             ],
+            timeout     => $initial_fact_timeout,
           }
         }
 
@@ -385,6 +392,7 @@ class pe_patch (
             path        => 'C:/Windows/System32/WindowsPowerShell/v1.0',
             refreshonly => true,
             command     => "powershell -executionpolicy remotesigned -file ${fact_cmd}",
+            timeout     => $initial_fact_timeout,
           }
         }
 

--- a/spec/classes/pe_patch_spec.rb
+++ b/spec/classes/pe_patch_spec.rb
@@ -177,7 +177,7 @@ describe 'pe_patch' do
       when 'windows'
         it { is_expected.to contain_scheduled_task('pe_patch fact generation').with_ensure('present') }
       end
-      it { is_expected.to contain_exec('pe_patch::exec::fact') }
+      it { is_expected.to contain_exec('pe_patch::exec::fact').with_timeout(900) }
       it { is_expected.to contain_exec('pe_patch::exec::fact_upload') }
 
       context 'block on warnings' do


### PR DESCRIPTION
Because gathering patch information can be slow, especially on Windows, it has been observed that the exec that runs the command to gather the initial fact information may timeout after the default 300 second exec timeout elapses.  This adds a parameter to pe_patch to allow for setting a different timeout, and sets it to 15 minutes by default. The timeout can be disabled entirely by setting it to 0. This does not affect the cron job/scheduled task, just the initial fact cmd exec.