### PR TITLE
(PE-29099) Update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,32 +7,19 @@
   "source": "https://github.com/puppetlabs/pe_patch",
   "project_page": "https://github.com/puppetlabs/pe_patch",
   "issues_url": "https://github.com/puppetlabs/pe_patch/issues",
-  "dependencies": [
-    {
-      "name": "puppet-cron",
-      "version_requirement": ">= 1.3.1 < 5.0.0"
-    },
-    {
-      "name": "puppetlabs-scheduled_task",
-      "version_requirement": ">= 1.0.1 < 5.0.0"
-    },
-    {
-      "name": "puppetlabs-cron_core",
-      "version_requirement": ">= 1.0.1 < 5.1.0"
-    }
-  ],
+  "dependencies": [],
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
@@ -40,13 +27,13 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "11",
         "12",
         "15"
       ]
@@ -62,14 +49,21 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "16.04",
-        "14.047"
+        "18.04"
+      ]
+    },
+    {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "30",
+        "31"
       ]
     },
     {
       "operatingsystem": "windows",
       "operatingsystemrelease": [
-        "2008",
-        "2008 R2",
+        "8.1",
+        "10",
         "2012",
         "2012 R2",
         "2016",
@@ -79,9 +73,9 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     }
   ],


### PR DESCRIPTION
This removes the dependencies, since they are always going to be present with puppet and the inclusion in the metadata throws a warning with 'puppet module list'. It also updates the supported operating system list to match docs.