### PR TITLE
(PE-29457) Fix blackout window validation in pe_patch fact

### DIFF
--- a/lib/facter/pe_patch.rb
+++ b/lib/facter/pe_patch.rb
@@ -91,7 +91,7 @@ else
         blackouts.each_line do |line|
           next if line.empty?
           next if line =~ /^#|^$/
-          matchdata = line.match(/^([\w ]*),(\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:\d{,2}:\d{,2}\+\d{,2}:\d{,2}),(\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:\d{,2}:\d{,2}[-\+]\d{,2}:\d{,2})$/)
+          matchdata = line.match(/^([\w ]*),(\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:\d{,2}:\d{,2}[-\+]\d{,2}:\d{,2}),(\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:\d{,2}:\d{,2}[-\+]\d{,2}:\d{,2})$/)
           if matchdata
             arraydata[matchdata[1]] = {} unless arraydata[matchdata[1]]
             if matchdata[2] > matchdata[3]


### PR DESCRIPTION
The regex used to validate the blackout window correctly matched both negative and positive UTC offsets in the second datetime parameter, but only matched positive ones in the first parameter. This fixes the regex to match it in both.