### PR TITLE
(PE-29468) Fix pe_patch fact when cached catalog is not what we expect

### DIFF
--- a/files/pe_patch_fact_generation.sh
+++ b/files/pe_patch_fact_generation.sh
@@ -54,11 +54,11 @@ SECUPDATEFILE="$DATADIR/security_package_updates"
 OSHELDPKGFILE="$DATADIR/os_version_locked_packages"
 CATHELDPKGFILE="$DATADIR/catalog_version_locked_packages"
 MISMATCHHELDPKGFILE="$DATADIR/mismatched_version_locked_packages"
-CATALOG="$(facter -p puppet_vardir)/client_data/catalog/$(puppet config print certname --section agent).json"
+CATALOG="$(puppet config print vardir)/client_data/catalog/$(puppet config print certname --section agent).json"
 
 if [ -f "${CATALOG}" ]
 then
-	VERSION_LOCK_FROM_CATALOG=$(cat $CATALOG | /opt/puppetlabs/puppet/bin/ruby -e "require 'json'; json_hash = JSON.parse(ARGF.read); json_hash['resources'].select { |r| r['type'] == 'Package' and r['parameters']['ensure'].match /\d.+/ }.each do | m | puts m['title'] end")
+	VERSION_LOCK_FROM_CATALOG=$(cat $CATALOG | /opt/puppetlabs/puppet/bin/ruby -e "require 'json'; begin; json_hash = JSON.parse(ARGF.read); json_hash['resources'].select { |r| r['type'] == 'Package' and r['parameters'] and r['parameters']['ensure'] and r['parameters']['ensure'].match /\d.+/ }.each do | m | puts m['title'] end; rescue; puts ''; end")
 else
 	VERSION_LOCK_FROM_CATALOG=''
 fi


### PR DESCRIPTION
Previously, the fact generation script would fail if it had problems parsing the cached catalog json file, including if a package resource did not contain a parameters hash. This wraps the json parsing in an exception handler that returns an empty string if it runs into trouble. It also validates the parsed hash so that it can attempt to find other version locked packages in the catalog if one of the resources has problems.

This also replaces the use of the puppet_vardir fact, since this is provided by puppetlabs-stdlib, which we do not ship with the module.  Instead, it gets vardir from puppet config print.