### PR TITLE
(maint) Fix blackout_windows error messages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -282,13 +282,13 @@ class pe_patch (
           fail('Blackout description can only contain alphanumerics, space, dash and underscore')
         }
         if ( $value['start'] !~ /^\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:\d{,2}:\d{,2}[-\+]\d{,2}:\d{,2}$/ ){
-          fail('Blackout start time must be in ISO 8601 format (YYYY-MM-DDTmm:hh:ss[-+]hh:mm)')
+          fail('Blackout start time must be in ISO 8601 format (YYYY-MM-DDThh:mm:ss[-+]hh:mm)')
         }
         if ( $value['end'] !~ /^\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:\d{,2}:\d{,2}[-\+]\d{,2}:\d{,2}$/ ){
-          fail('Blackout end time must be in ISO 8601 format  (YYYY-MM-DDTmm:hh:ss[-+]hh:mm)')
+          fail('Blackout end time must be in ISO 8601 format  (YYYY-MM-DDThh:mm:ss[-+]hh:mm)')
         }
         if ( $value['start'] > $value['end'] ){
-          fail('Blackout end time must after the start time')
+          fail('Blackout end time must be after the start time')
         }
       }
     }


### PR DESCRIPTION
The error message gave the wrong format for ISO 8601 time, and another error was missing a word.