### PR TITLE
(PE-29920) Only fetch Windows updates of type 'Software' and allow override of criteria

### DIFF
--- a/tasks/patch_server.json
+++ b/tasks/patch_server.json
@@ -32,7 +32,7 @@
   },
   "implementations": [
     { "name": "patch_server.rb", "requirements": ["shell"]},
-    { "name": "patch_server.rb", "requirements": ["powershell"], "files": ["pe_patch/files/pe_patch_groups.ps1"]}
+    { "name": "patch_server.rb", "requirements": ["powershell"]}
   ],
   "puppet_task_version": 1,
   "supports_noop": false,

--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -19,6 +19,7 @@ if IS_WINDOWS
   # set paths/commands for windows
   fact_generation_script = 'C:/ProgramData/pe_patch/pe_patch_fact_generation.ps1'
   fact_generation_cmd = "#{ENV['systemroot']}/system32/WindowsPowerShell/v1.0/powershell.exe -ExecutionPolicy RemoteSigned -file #{fact_generation_script}"
+  patch_script = 'C:/ProgramData/pe_patch/pe_patch_groups.ps1'
   puppet_cmd = "#{ENV['programfiles']}/Puppet Labs/Puppet/bin/puppet"
   shutdown_cmd = 'shutdown /r /t 60 /c "Rebooting due to the installation of updates by pe_patch" /d p:2:17'
 else
@@ -560,7 +561,7 @@ elsif facts['values']['os']['family'] == 'windows'
 
   # build patching command
   powershell_cmd = "#{ENV['systemroot']}/system32/WindowsPowerShell/v1.0/powershell.exe -NonInteractive -ExecutionPolicy RemoteSigned -File"
-  win_patching_cmd = "#{powershell_cmd} #{params['_installdir']}/pe_patch/files/pe_patch_groups.ps1 #{security_arg} -Timeout #{timeout}"
+  win_patching_cmd = "#{powershell_cmd} #{patch_script} #{security_arg} -Timeout #{timeout}"
 
   log.info 'Running patching powershell script'
 

--- a/templates/pe_patch_fact_generation.ps1.epp
+++ b/templates/pe_patch_fact_generation.ps1.epp
@@ -24,12 +24,12 @@ Performs an update scan, and refreshes update related facts, for the puppet modu
 Performs an update scan, and refreshes update related facts, for the puppet module pe_patch. This script is intended to be run as part of the pe_patch module, however it will also function standalone.
 
 .PARAMETER UpdateCriteria
-Criteria used for update detection. This ultimately drives which updates will be installed. The detault is "IsInstalled=0 and IsHidden=0" which should be suitable in most cases, and relies on your upstream update approvals. Note that this is not validated, if the syntax is not validated the script will fail. See MSDN doco for valid syntax - https://docs.microsoft.com/en-us/windows/desktop/api/wuapi/nf-wuapi-iupdatesearcher-search.
+Criteria used for update detection. This ultimately drives which updates will be installed. The default for this script is determined by pe_patch::windows_update_criteria, and is "IsInstalled=0 and IsHidden=0 and Type='Software'" unless otherwise specified, which should be suitable in most cases, and relies on your upstream update approvals. Note that this is not validated, if the syntax is not validated the script will fail. See MSDN doco for valid syntax - https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdatesearcher-search
 #>
 
 [CmdletBinding()]
 param(
-    [String]$UpdateCriteria = "IsInstalled=0 and IsHidden=0",
+    [String]$UpdateCriteria = "<%= $windows_update_criteria %>",
 
     # path to lock file
     # default to same one as pe_patch_groups so this won't run at the same time

--- a/templates/pe_patch_groups.ps1.epp
+++ b/templates/pe_patch_groups.ps1.epp
@@ -33,7 +33,7 @@ Force running in scheduled task mode. This indended for use in a remote session,
 Switch, when set the script will only install updates with a category that includes Security Update.
 
 .PARAMETER UpdateCriteria
-Criteria used for update detection. This ultimately drives which updates will be installed. The detault is "IsInstalled=0 and IsHidden=0" which should be suitable in most cases, and relies on your upstream update approvals. Note that this is not validated, if the syntax is not validated the script will fail. See MSDN doco for valid syntax - https://docs.microsoft.com/en-us/windows/desktop/api/wuapi/nf-wuapi-iupdatesearcher-search.
+Criteria used for update detection. This ultimately drives which updates will be installed. The default for this script is determined by pe_patch::windows_update_criteria, and is "IsInstalled=0 and IsHidden=0 and Type='Software'" unless otherwise specified, which should be suitable in most cases, and relies on your upstream update approvals. Note that this is not validated, if the syntax is not validated the script will fail. See MSDN docs for valid syntax - https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdatesearcher-search
 
 .PARAMETER MaxUpdates
 Install only the first X numbmer of updates (at most). Useful ror testing.
@@ -81,7 +81,7 @@ param(
     # update criteria
     [Parameter(ParameterSetName = "InstallUpdates-Forcelocal")]
     [Parameter(ParameterSetName = "InstallUpdates-ForceSchedTask")]
-    [String]$UpdateCriteria = "IsInstalled=0 and IsHidden=0",
+    [String]$UpdateCriteria = "<%= $windows_update_criteria %>",
 
     [Parameter(ParameterSetName = "InstallUpdates-Forcelocal")]
     [Parameter(ParameterSetName = "InstallUpdates-ForceSchedTask")]


### PR DESCRIPTION
Previously, the criteria used for searching for Windows updates to install was 'IsInstalled=0 and IsHidden=0'. This caused driver updates to appear in the list of patches to apply. Most people only care about 'Software' type updates (which is most of everything else), and would prefer not to install drivers via this method. This changes the default to IsInstalled=0 and IsHidden=0 and Type='Software'.

Additionally, a pe_patch::windows_update_criteria parameter is added to the class. This allows the user to define their own criteria to search for updates. To support this, the pe_patch_fact_generation.ps1 and pe_patch_groups.ps1 files are now templates, so that we can inject the value of pe_patch::windows_update_criteria into them. Also, pe_patch_groups.ps1 is now laid down by the pe_patch class on the target, rather than being delivered by the patch_server task, and the patch_server task calls this file. This allows us to use the value a user might have chosen for windows_update_criteria, since we don't have a good way of providing a templated file to a task.