### PR TITLE
(PE-30310) Use the content attribute to define fact generation file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -220,12 +220,15 @@ class pe_patch (
     }
 
     case $::kernel {
+      # Because this module resides in the base modulepath, we can not
+      # serve the file statically with 'source', so we use 'content'
+      # to avoid excessive file metadata checks at scale.
       'Linux': {
         file { $fact_cmd:
-          ensure => $ensure_file,
-          mode   => $fact_mode,
-          source => "puppet:///modules/${module_name}/${fact_file}",
-          notify => Exec[$fact_exec],
+          ensure  => $ensure_file,
+          mode    => $fact_mode,
+          content => file("${module_name}/${fact_file}"),
+          notify  => Exec[$fact_exec],
         }
       }
       'windows': {


### PR DESCRIPTION
Because this module resides in the base modulepath, we can not serve the file statically using the 'source' attribute. Using this causes excessive file metadata checks. Instead, this modifies the file resource to provide the content of the file. This increases the catalog size, but prevents metadata checks.