### PR TITLE
(maint) Remove branch restrictions from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,12 +81,6 @@ matrix:
     -
       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
       rvm: 2.4.4
-branches:
-  only:
-    - master
-    - /^v\d/
-    - release
-    - development
 notifications:
   email: false
 


### PR DESCRIPTION
We don't need to restrict branches to run Travis now. This will make it easier to create new branches for different PE versions.