### PR TITLE
Update .travis.yml matrix -> jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ rvm:
 env:
   global:
     - PUPPET_GEM_VERSION="~> 6.0"
-matrix:
+jobs:
   fast_finish: true
   # These are here for historical purposes since they were
   # there for os_patching, in case we want to use litmus in


### PR DESCRIPTION
This uses `jobs` instead of `matrix`.  We don't need a matrix here since we're only testing one branch, and this was causing tests to run twice. 

Edit: Wasn't actually this.  Oops.