### PR TITLE
(PE-30674) Support puppet 7

### DIFF
--- a/tasks/clean_cache.rb
+++ b/tasks/clean_cache.rb
@@ -57,7 +57,7 @@ end
 
 # Cache the facts
 log.debug 'Gathering facts'
-full_facts, stderr, status = Open3.capture3('/opt/puppetlabs/puppet/bin/puppet', 'facts')
+full_facts, stderr, status = Open3.capture3('/opt/puppetlabs/puppet/bin/puppet', 'facts', 'find')
 err(status, 'pe_patch/facter', stderr, starttime) if status != 0
 facts = JSON.parse(full_facts)
 

--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -261,7 +261,7 @@ end
 
 # Cache the facts
 log.debug 'Gathering facts'
-full_facts, stderr, status = Open3.capture3(puppet_cmd, 'facts')
+full_facts, stderr, status = Open3.capture3(puppet_cmd, 'facts', 'find')
 err(status, 'pe_patch/facter', stderr, starttime) if status != 0
 facts = JSON.parse(full_facts)
 


### PR DESCRIPTION
The default action for `puppet facts` has changed in puppet 7.  Explicitly use
`puppet facts find` so it works on all versions.