### PR TITLE
make $fact_dir customisable for linux

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -129,6 +129,7 @@
 #     ensure => absent,
 #   }
 class pe_patch (
+  String $linux_fact_dir              = '/usr/local/bin',
   String $patch_data_owner            = 'root',
   String $patch_data_group            = 'root',
   String $patch_cron_user             = $patch_data_owner,
@@ -172,7 +173,7 @@ class pe_patch (
       'Linux': {
         $fact_upload_cmd     = '/opt/puppetlabs/bin/puppet facts upload'
         $cache_dir           = '/var/cache/pe_patch'
-        $fact_dir            = '/usr/local/bin'
+        $fact_dir            = $linux_fact_dir
         $fact_file           = 'pe_patch_fact_generation.sh'
         $fact_mode           = '0700'
         File {


### PR DESCRIPTION
Some customers have /usr/local/bin mounted as read only, or would otherwise prefer not to have this script placed here.

This PR does not alter the default behavior but exposes a parameter to allow you to customize fact_dir on linux