### PR TITLE
(PE-30739) pe_patch_tasks.log should not be cleaned up

### DIFF
--- a/templates/pe_patch_groups.ps1.epp
+++ b/templates/pe_patch_groups.ps1.epp
@@ -857,7 +857,7 @@ try {
     }
 
     # clean log files
-    Invoke-CleanLogFile -LogFileFilter "pe_patch*.log"
+    Invoke-CleanLogFile -LogFileFilter "pe_patch-*.log"
 }
 finally {
     # this code is always executed, even when an exception is trapped during main script execution


### PR DESCRIPTION
On Windows for logging purposes there is `pe_patch_tasks.log` and
indivual runs of the task have `pe_patch-<timestamp>.log`.
When we attempt to clean up the unique log files, we're accidently
trying to clean up the pe_patch_tasks.log file.
This is causing the task to fail since we're activly writing to
something that we try to delete.
Since the main log file has two underscores versus the individual log
files having one underscore then a dash, if we just add the dash to
the filter it looks to solve the issue. The old individual log files
get deleted, and a new one is created for the task that just ran.