### PR TITLE
Merge-up 2019.8.x to main 2021_01_28_19_42

### DIFF
--- a/plans/group_patching.pp
+++ b/plans/group_patching.pp
@@ -1,10 +1,15 @@
 plan pe_patch::group_patching (
   String $patch_group,
-  Boolean $security_only = false,
-  Enum['always', 'never', 'patched', 'smart'] $reboot = 'patched',
-  Integer $reboot_wait_time = 600,
-  Boolean $run_health_check = true,
+  Optional[Enum['always', 'never', 'patched', 'smart']] $reboot = 'patched',
+  Optional[String] $yum_params = undef,
+  Optional[String] $dpkg_params = undef,
+  Optional[String] $zypper_params = undef,
+  Optional[Integer] $patch_task_timeout = 3600,
   Optional[Integer] $health_check_runinterval = 1800,
+  Optional[Integer] $reboot_wait_time = 600,
+  Optional[Boolean] $security_only = false,
+  Optional[Boolean] $run_health_check = true,
+  Optional[Boolean] $clean_cache = false,
   Optional[Boolean] $health_check_noop = false,
   Optional[Boolean] $health_check_use_cached_catalog = false,
   Optional[Boolean] $health_check_service_enabled = true,
@@ -66,8 +71,13 @@ plan pe_patch::group_patching (
       # Actually carry out the patching on all healthy nodes
       $patch_result = run_task('pe_patch::patch_server',
                             $patch_ready,
+                            yum_params      => $yum_params,
+                            dpkg_params     => $dpkg_params,
+                            zypper_params   => $zypper_params,
+                            timeout         => $patch_task_timeout,
                             reboot          => $reboot,
                             security_only   => $security_only,
+                            clean_cache     => $clean_cache
                             '_catch_errors' => true)
 
       # Pull out list of those that are ok/in error


### PR DESCRIPTION
[Generated using mergeup script](https://github.com/puppetlabs/pe-dev-scripts/blob/master/workflow/mergeup.sh)

* 2019.8.x:
  (PE-30990) Pass-through remaining pe_patch::patch_server params through group_patching plan