### PR TITLE
Merge-up 2019.8.x to main 2021_01_29_20_25

### DIFF
--- a/plans/group_patching.pp
+++ b/plans/group_patching.pp
@@ -126,10 +126,11 @@ plan pe_patch::group_patching (
             $timed_out = $elapsed_time_sec >= $reboot_wait_time
 
             if !$failed_targets.empty and !$timed_out {
-              # Wait for targets to be available again before rechecking
+              # Wait for targets to be available again before rechecking. If we end up failing
+              # this wait on any of those nodes, we'll catch it in the next iteration.
               pe_patch::sleep(30)
               $remaining_time = $reboot_wait_time - $elapsed_time_sec
-              wait_until_available($failed_targets, wait_time => $remaining_time, retry_interval => 1)
+              wait_until_available($failed_targets, wait_time => $remaining_time, retry_interval => 1, '_catch_errors' => true)
             }
 
             ({

--- a/tasks/agent_health.rb
+++ b/tasks/agent_health.rb
@@ -5,8 +5,44 @@ require 'time'
 require 'json'
 require 'socket'
 
-confprint = 'puppet config print --render-as json'
-output, stderr, status = Open3.capture3(confprint)
+# Lifted from https://github.com/puppetlabs/enterprise_tasks/blob/c8855bb3198567e40204178682b094f924af5754/lib/enterprise_tasks/puppet_helper.rb#L7
+def puppet_bin
+  if Gem.win_platform?
+    require 'win32/registry'
+    installed_dir =
+      begin
+        Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Puppet Labs\Puppet') do |reg|
+          # rubocop:disable Style/RescueModifier
+          # Rescue missing key
+          dir = reg['RememberedInstallDir64'] rescue ''
+          # Both keys may exist, make sure the dir exists
+          break dir if File.exist?(dir)
+
+          # Rescue missing key
+          reg['RememberedInstallDir'] rescue ''
+          # rubocop:enable Style/RescueModifier
+        end
+      rescue Win32::Registry::Error
+        # Rescue missing registry path
+        ''
+      end
+
+    path =
+      if installed_dir.empty?
+        # Fall back to assuming it's on the PATH
+        'puppet'
+      else
+        File.join(installed_dir, 'bin', 'puppet.bat')
+      end
+  else
+    path = '/opt/puppetlabs/puppet/bin/puppet'
+  end
+  path
+end
+
+puppet_cmd = puppet_bin
+
+output, stderr, status = Open3.capture3(puppet_cmd, 'config', 'print', '--render-as', 'json')
 if status != 0
   puts stderr
   exit 1
@@ -129,14 +165,14 @@ if File.file?(last_run_report_file)
   end
 end
 
-_output, _stderr, status = Open3.capture3('puppet ssl verify')
+_output, _stderr, status = Open3.capture3(puppet_cmd, 'ssl', 'verify')
 if status != 0
   details['issues']['signed_cert'] = 'SSL verify error'
 end
 
 enabled = false
 running = false
-output, _stderr, _status = Open3.capture3('puppet resource service puppet')
+output, _stderr, _status = Open3.capture3(puppet_cmd, 'resource', 'service', 'puppet')
 output.split("\n").each do |line|
   if line =~ %r{^\s+enable\s+=> '#{target_service_enabled}',$}
     enabled = true
@@ -183,7 +219,7 @@ else
   exit_code = 1
   json[:_error] = { 
                     msg: "Issues found: " + details['issues'].to_s,
-                    kind: 'puppet_health_check/agent_health',
+                    kind: 'pe_patch/agent_health',
                     details: details,
                   }
 end


### PR DESCRIPTION
[Generated using mergeup script](https://github.com/puppetlabs/pe-dev-scripts/blob/master/workflow/mergeup.sh)

* 2019.8.x:
  (PE-31025,PE-30725) Look up installed path for Puppet on Windows and use Gem to determine if we're on Windows
  (maint) Don't fail plan if wait_until_available fails during reboot check
  (PE-31025) Use full path to puppet in pe_patch tasks