### PR TITLE
(PE-30691) Add max_timeout parameter to puppet runs in group_patching

### DIFF
--- a/plans/group_patching.pp
+++ b/plans/group_patching.pp
@@ -50,7 +50,9 @@ plan pe_patch::group_patching (
       if $puppet_healthy.empty {
         $patch_ready = []
       } else {
-        $pre_patch_run_puppet_check = run_task('enterprise_tasks::run_puppet', $puppet_healthy, '_catch_errors' => true)
+        $pre_patch_run_puppet_check = run_task('enterprise_tasks::run_puppet', $puppet_healthy,
+          max_timeout     => 256,
+          '_catch_errors' => true)
         $patch_ready = $pre_patch_run_puppet_check.ok_set.names
         $pre_patch_puppet_run_failed = $pre_patch_run_puppet_check.error_set.names
       }
@@ -160,7 +162,9 @@ plan pe_patch::group_patching (
     } else {
       # Sometimes a puppet run immediately after reboot fails, so give it a bit of time.
       pe_patch::sleep(30)
-      $post_puppet_check = run_task('enterprise_tasks::run_puppet', $post_patch_ready, '_catch_errors' => true)
+      $post_puppet_check = run_task('enterprise_tasks::run_puppet', $post_patch_ready,
+        max_timeout     => 256,
+        '_catch_errors' => true)
       $post_patch_puppet_run_passed = $post_puppet_check.ok_set.names
       $post_patch_puppet_run_failed = $post_puppet_check.error_set.names
     }


### PR DESCRIPTION
Because we could try to do puppet runs at the same time the puppet service is doing a run, this adds the max_timeout parameter to the calls to enterprise_tasks::run_puppet so that we can wait for those runs to finish before we do our pre/post-patching puppet runs.