### PR TITLE
(PE-30736) Pipe `facts upload` execution output to null

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,7 +175,7 @@ class pe_patch (
 
     case $::kernel {
       'Linux': {
-        $fact_upload_cmd     = '/opt/puppetlabs/bin/puppet facts upload'
+        $fact_upload_cmd     = '/opt/puppetlabs/bin/puppet facts upload > /dev/null'
         $cache_dir           = '/opt/puppetlabs/pe_patch'
         $fact_dir            = $cache_dir
         $fact_file           = 'pe_patch_fact_generation.sh'
@@ -196,7 +196,7 @@ class pe_patch (
         }
       }
       'windows': {
-        $fact_upload_cmd     = '"C:/Program Files/Puppet Labs/Puppet/bin/puppet.bat" facts upload'
+        $fact_upload_cmd     = '"C:/Program Files/Puppet Labs/Puppet/bin/puppet.bat" facts upload > $null'
         $cache_dir           = 'C:/ProgramData/PuppetLabs/pe_patch'
         $fact_dir            = $cache_dir
         $fact_file           = 'pe_patch_fact_generation.ps1'


### PR DESCRIPTION
When pe_patch_fact_generation runs, it echoes "Uploading facts" anytime anything has changed, which results in a large number of cron emails and has created multiple requests from customers to reduce this spam. This PR pipes the facts upload execution sdtout to /dev/null (or the windows equivalent) to silence these emails