### PR TITLE
(PE-30736) Send echoed output to logger

### DIFF
--- a/templates/pe_patch_fact_generation.sh.epp
+++ b/templates/pe_patch_fact_generation.sh.epp
@@ -155,10 +155,10 @@ diff=$(diff -y --suppress-common "${UPDATEFILE}" "${UPDATEFILE}.previous" | wc -
 rm -f "${UPDATEFILE}.previous"
 if [ "${diff}" != "0" ]
 then
-  echo "Uploading facts"
+  logger -p info -t pe_patch_fact_generation.sh "Uploading facts"
   puppet facts upload --environment "<%= $environment %>" 2>/dev/null 1>/dev/null
 fi
-logger -p info -t pe_patch_fact_generation.sh "patch data refreshed"
+logger -p info -t pe_patch_fact_generation.sh "Patch data refreshed"
 
 rm $LOCKFILE
 exit 0


### PR DESCRIPTION
When pe_patch_fact_generation runs, it echoes "Uploading facts" anytime anything has changed, which results in a large number of cron emails and has created multiple requests from customers to reduce this spam. This pr sends this echo instead to logs like the windows equivalent already does.