### PR TITLE
(PE-30966) Use drpm on el-8 platforms

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -380,8 +380,15 @@ class pe_patch (
         }
 
         if ( $::osfamily == 'RedHat' and $manage_delta_rpm) {
-          package { 'deltarpm':
-            ensure => $delta_rpm,
+          if (Integer($facts['os']['release']['major']) < 8 or $facts['os']['name'] == 'Fedora') {
+            package { 'deltarpm':
+              ensure => $delta_rpm,
+            }
+          }
+          else {
+            package { 'drpm':
+              ensure => $delta_rpm,
+            }
           }
         }
 

--- a/spec/classes/pe_patch_spec.rb
+++ b/spec/classes/pe_patch_spec.rb
@@ -41,7 +41,12 @@ describe 'pe_patch' do
               'manage_yum_plugin_security' => true,
             }
           }
-          it { is_expected.to contain_package('deltarpm') }
+
+          if os_facts[:os]['release']['major'] == '8'
+            it { is_expected.to contain_package('drpm') }
+          else
+            it { is_expected.to contain_package('deltarpm') }
+          end
           it { is_expected.to contain_package('yum-utils') }
           it { is_expected.to contain_package('yum-plugin-security') }
         end


### PR DESCRIPTION
The `deltarpm` package was renamed to `drpm` on el-8 platforms, this
commit fixes an issue with `$manage_delta_rpm` where it would try to
install `deltarpm` on el-8 platforms, which results in an error. It
should now install `drpm` which has the same function but is correctly
named.

This change also excludes Fedora, since that has an osfamily of `RedHat`
but since its version numbers are all greater than 8 and it still has
`deltarpm` available, it continues to use deltarpm.