### PR TITLE
Update the SUSE PKGS, SECPKGS, and HELDPKGS

### DIFF
--- a/templates/pe_patch_fact_generation.sh.epp
+++ b/templates/pe_patch_fact_generation.sh.epp
@@ -33,9 +33,9 @@ case $(facter osfamily) in
     HELDPKGS=$([ -r /etc/yum/pluginconf.d/versionlock.list ] && awk -F':' '/:/ {print $2}' /etc/yum/pluginconf.d/versionlock.list | sed 's/-[0-9].*//')
   ;;
   Suse)
-    PKGS=$(zypper --non-interactive --no-abbrev --quiet lu | grep '|' | grep -v '\sRepository' | awk -F'|' '/^[[:alnum:]]/ {print $3}' | sed 's/^\s*\|\s*$//')
-    SECPKGS=$(zypper --non-interactive --no-abbrev --quiet lp -g security | grep '|' | grep -v '^Repository' | awk -F'|' '/^[[:alnum:]]/ {print $2}' | sed 's/^\s*\|\s*$//')
-    HELDPKGS=$(zypper --non-interactive --no-abbrev --quiet ll | grep '|' | grep -v '^Repository' | awk -F'|' '/^[[:alnum:]]/ {print $2}' | sed 's/^\s*\|\s*$//')
+    PKGS=$(zypper --non-interactive --no-abbrev --quiet lu | tail -n +3 | awk -F'|' '/^[[:alnum:]]/ {print $3}' | sed 's/^\s*\|\s*$//')
+    SECPKGS=$(zypper --non-interactive --no-abbrev --quiet lp -g security | tail -n +3 | awk -F'|' '/^[[:alnum:]]/ {print $2}' | sed 's/^\s*\|\s*$//')
+    HELDPKGS=$(zypper --non-interactive --no-abbrev --quiet ll | tail -n +3 | awk -F'|' '/^[[:alnum:]]/ {print $2}' | sed 's/^\s*\|\s*$//')
   ;;
   Debian)
     PKGS=$(apt upgrade -s 2>/dev/null | awk '$1 == "Inst" {print $2}')


### PR DESCRIPTION
The current regex used for SUSE OSes to try and exclude the header lines fails to properly select patches if the repository name actually includes the word Repository (like "Main Update Repository", which is the default main update repository).  There's an additional regex that is used simply to exclude the header separator.  This change uses tail -n +3 to simply skip the header lines altogether and avoids the necessity of two greps.