### PR TITLE
(PE-32388) Account for long usernames in yum history

### DIFF
--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -540,7 +540,7 @@ if facts['values']['os']['family'] == 'RedHat'
       # ID     | Login user               | Date and time    | 8< SNIP >8
       # ------------------------------------------------------ 8< SNIP >8
       #     69 | System <unset>           | 2018-09-17 17:18 | 8< SNIP >8
-      matchdata = line.to_s.match(/^\s+(\d+)\s*\|\s*[\w\-<> ]*\|\s*([\d:\- ]*)/)
+      matchdata = line.to_s.match(/^\s+(\d+)\s*\|\s*[\w\.\-<> ]*\|\s*([\d:\- ]*)/)
       next unless matchdata
       job = matchdata[1]
       yum_end = matchdata[2]


### PR DESCRIPTION
Prior to this commit, when long usernames appeared in yum history with the "..." concatenation like this:

112 | admin ... <lnxdcom> | 2020-10-23 10:17 | Install | 1 ><

it would cause the error message to appear "Yum did not appear to run" as the regex could not handle the dots.

This commit brings pe_patch in line with a bug fix in puppet_os_patching referenced in this commit sharumpe/puppet_os_patching@c1cc8e2