### PR TITLE
Merge-up 2019.8.x to main 2021_08_02_20_30

### DIFF
--- a/templates/pe_patch_fact_generation.sh.epp
+++ b/templates/pe_patch_fact_generation.sh.epp
@@ -39,7 +39,7 @@ case $(facter osfamily) in
   ;;
   Debian)
     PKGS=$(apt upgrade -s 2>/dev/null | awk '$1 == "Inst" {print $2}')
-    SECPKGS=$(apt upgrade -s 2>/dev/null | awk '$1 == "Inst" && /security/ {print $2}')
+    SECPKGS=$(apt upgrade -s 2>/dev/null | awk '$1 == "Inst" && /[Ss]ecurity/ {print $2}')
     HELDPKGS=$(dpkg --get-selections | awk '$2 == "hold" {print $1}')
   ;;
   *)


### PR DESCRIPTION
[Generated using mergeup script](https://github.com/puppetlabs/pe-dev-scripts/blob/master/workflow/mergeup.sh)

* 2019.8.x:
  (PE-32514) Update Debian's regex for security packages search