### PR TITLE
(PE-29622) Update blackout windows validation regex

### DIFF
--- a/lib/facter/pe_patch.rb
+++ b/lib/facter/pe_patch.rb
@@ -105,7 +105,7 @@ else
         blackouts.each_line do |line|
           next if line.empty?
           next if line =~ /^#|^$/
-          matchdata = line.match(/^([\w ]*),(\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:\d{,2}:\d{,2}[-\+]\d{,2}:\d{,2}),(\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:\d{,2}:\d{,2}[-\+]\d{,2}:\d{,2})$/)
+          matchdata = line.match(/^([\w ]*),(\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:?\d{,2}:?\d{,2}[-\+]\d{,2}:?\d{,2}),(\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:?\d{,2}:?\d{,2}[-\+]\d{,2}:?\d{,2})$/)
           if matchdata
             arraydata[matchdata[1]] = {} unless arraydata[matchdata[1]]
             if matchdata[2] > matchdata[3]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -337,10 +337,10 @@ class pe_patch (
         if ( $key !~ /^[A-Za-z0-9\-_ ]+$/ ){
           fail('Blackout description can only contain alphanumerics, space, dash and underscore')
         }
-        if ( $value['start'] !~ /^\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:\d{,2}:\d{,2}[-\+]\d{,2}:\d{,2}$/ ){
+        if ( $value['start'] !~ /^\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:?\d{,2}:?\d{,2}[-\+]\d{,2}:?\d{,2}$/ ){
           fail('Blackout start time must be in ISO 8601 format (YYYY-MM-DDThh:mm:ss[-+]hh:mm)')
         }
-        if ( $value['end'] !~ /^\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:\d{,2}:\d{,2}[-\+]\d{,2}:\d{,2}$/ ){
+        if ( $value['end'] !~ /^\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:?\d{,2}:?\d{,2}[-\+]\d{,2}:?\d{,2}$/ ){
           fail('Blackout end time must be in ISO 8601 format  (YYYY-MM-DDThh:mm:ss[-+]hh:mm)')
         }
         if ( $value['start'] > $value['end'] ){


### PR DESCRIPTION
This updates the blackout_windows validation regex to allow for the inclusion or omission of colons, as these are not required by ISO8601.