### PR TITLE
PE-32952 Use yum history_list_view option

### DIFF
--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -532,7 +532,7 @@ if facts['values']['os']['family'] == 'RedHat'
     # Capture the yum job ID
     log.info 'Getting yum job ID'
     job = ''
-    yum_id, stderr, status = Open3.capture3('yum history')
+    yum_id, stderr, status = Open3.capture3('yum --setopt=history_list_view=users history')
     err(status, 'pe_patch/yum', stderr, starttime) if status != 0
     yum_id.split("\n").each do |line|
       # Quite the regex.  This pulls out fields 1 & 3 from the first info line


### PR DESCRIPTION
Yum prints coomandline info instead of users info as the second column
in the 'yum history' output on RedHat8 by default. If the commandline
includes '*' or '=' characters, the regex won't match the line and the
task will report error even though yum actually ran.
Replace 'yum history' with 'yum --setopt=history_list_view=users
history' which will print users info instead of commandline on el-6, 7
and 8