### PR TITLE
(PE-33237) Remove duplicates from KB lists in pe_patch_fact_generation.ps1

### DIFF
--- a/templates/pe_patch_fact_generation.ps1.epp
+++ b/templates/pe_patch_fact_generation.ps1.epp
@@ -311,14 +311,14 @@ function Invoke-RefreshPuppetFacts {
     $allUpdates | Select-Object -ExpandProperty Title | Out-File $updateFile -Encoding ascii
 
     # output list of KBs that need to be applied
-    $allUpdates | ForEach-Object { $_.KBArticleIDs | ForEach-Object { "KB$_" } } | Out-File $kbFile -Encoding ascii
+    $allUpdates | ForEach-Object { $_.KBArticleIDs | ForEach-Object { "KB$_" } } | Select-Object -Unique | Out-File $kbFile -Encoding ascii
 
     # filter to security updates and output
     $securityUpdates | Select-Object -ExpandProperty Title | Out-File $secUpdateFile -Encoding ascii
 
     if ($securityUpdates -ne $null) {
         # output list of KBs that need to be applied
-        $securityUpdates | ForEach-Object { $_.KBArticleIDs | ForEach-Object { "KB$_" } } | Out-File $secKbFile -Encoding ascii
+        $securityUpdates | ForEach-Object { $_.KBArticleIDs | ForEach-Object { "KB$_" } } | Select-Object -Unique | Out-File $secKbFile -Encoding ascii
     } else {
         $securityUpdates | Out-File $secKbFile -Encoding ascii
     } 


### PR DESCRIPTION
Occasionally, Microsoft will put out multiple packages tied to the same KB (see the ticket for an example). Since this field is intended just to be a list of KBs remedied by the patches to be applied, we can remove any duplicates in this list. The multiple packages for the same KB will still get applied.