### PR TITLE
Merge-up 2019.8.x to main 2022_02_04_18_42

### DIFF
--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -232,7 +232,10 @@ def err(code, kind, message, starttime)
 end
 
 # Figure out if we need to reboot
-def reboot_required(family, release, reboot)
+def reboot_required(facts, reboot)
+  family = facts['values']['os']['family']
+  release = facts['values']['os']['release']['major']
+  osname = facts['values']['os']['name']
   # Do the easy stuff first
   if ['always', 'patched'].include?(reboot)
     true
@@ -240,7 +243,7 @@ def reboot_required(family, release, reboot)
     false
   elsif family == 'RedHat' && File.file?('/usr/bin/needs-restarting') && reboot == 'smart'
     response = ''
-    if release.to_i > 6
+    if release.to_i > 6 || osname =~ /Amazon/
       _output, _stderr, status = Open3.capture3('/usr/bin/needs-restarting -r')
       response = if status != 0
                    true
@@ -276,7 +279,7 @@ end
 
 def do_reboot_if_needed(reboot, facts, shutdown_cmd, log = nil)
   # Reboot if the task has been told to and there is a requirement OR if reboot_override is set to true
-  needs_reboot = reboot_required(facts['values']['os']['family'], facts['values']['os']['release']['major'], reboot)
+  needs_reboot = reboot_required(facts, reboot)
   log.info "reboot_required returning #{needs_reboot}" if log
   if needs_reboot == true
     log.info 'Rebooting' if log
@@ -528,7 +531,7 @@ if facts['values']['os']['family'] == 'RedHat'
   status, output = run_with_timeout("yum #{yum_params} #{securityflag} upgrade -y", timeout, 2)
   err(status, 'pe_patch/yum', "yum upgrade returned non-zero (#{status}) : #{output}", starttime) if status != 0
 
-  if facts['values']['os']['release']['major'].to_i > 5
+  if facts['values']['os']['release']['major'].to_i > 5 || facts['values']['os']['name'] =~ /Amazon/
     # Capture the yum job ID
     log.info 'Getting yum job ID'
     job = ''
@@ -578,7 +581,14 @@ if facts['values']['os']['family'] == 'RedHat'
     log.debug "Getting updated package list for job #{job}"
     updated_packages, stderr, status = Open3.capture3("yum history info #{job}")
     err(status, 'pe_patch/yum', stderr, starttime) if status != 0
-    updated_packages.split("\n").each do |line|
+    # Older versions of yum add "Transaction performed with" to the output, with 
+    # installed package lines. We want to skip those so they are not included
+    # in the list of packages we just updated. If we can't find it, err on 
+    # the side of caution and don't filter the lines at all.
+    lines = updated_packages.split("\n")
+    index = lines.index { |l| l =~ /Packages Altered/ } || 0
+    lines = lines.drop(index)
+    lines.each do |line|
       matchdata = line.match(/^\s+(Installed|Install|Upgraded|Erased|Updated)\s+(\S+)\s/)
       next unless matchdata
       pkg_hash[matchdata[2]] = matchdata[1]

--- a/templates/pe_patch_fact_generation.sh.epp
+++ b/templates/pe_patch_fact_generation.sh.epp
@@ -30,7 +30,7 @@ case $(facter osfamily) in
     PKGS=$(echo $PKGS | sed 's/Obsoleting.*//')
     SECPKGS=$(yum -q --security check-update 2>/dev/null | egrep -v "^Security:|is broken|^Loaded plugins|^You should report|^To help pinpoint" | awk '/^[[:alnum:]]/ {print $1}')
     SECPKGS=$(echo $SECPKGS | sed 's/Obsoleting.*//')
-    HELDPKGS=$([ -r /etc/yum/pluginconf.d/versionlock.list ] && awk -F':' '/:/ {print $2}' /etc/yum/pluginconf.d/versionlock.list | sed 's/-[0-9].*//')
+    HELDPKGS=$([ -r /etc/yum/pluginconf.d/versionlock.list ] && sed 's/^#.*//' /etc/yum/pluginconf.d/versionlock.list | awk -F':' '/:/ {if ($1 ~ /^[0-9]/) {print $2} else {print $1}}' | sed 's/-[0-9].*//')
   ;;
   Suse)
     PKGS=$(zypper --non-interactive --no-abbrev --quiet lu | grep '|' | grep -v '\sRepository' | awk -F'|' '/^[[:alnum:]]/ {print $3}' | sed 's/^\s*\|\s*$//')
@@ -109,16 +109,6 @@ done
 if [ -f '/usr/bin/needs-restarting' ]
 then
   case $(facter os.release.major) in
-    7)
-      /usr/bin/needs-restarting -r 2>/dev/null 1>/dev/null
-      if [ $? -gt 0 ]
-      then
-        echo "true" > $DATADIR/reboot_required
-      else
-        echo "false" > $DATADIR/reboot_required
-      fi
-      /usr/bin/needs-restarting 2>/dev/null | sed 's/[[:space:]]*$//' >$DATADIR/apps_to_restart
-    ;;
     6)
       /usr/bin/needs-restarting 2>/dev/null 1>$DATADIR/apps_to_restart
       if [ $? -gt 0 ]
@@ -133,6 +123,16 @@ then
           echo "false" > $DATADIR/reboot_required
         fi
       fi
+    ;;
+    *)
+      /usr/bin/needs-restarting -r 2>/dev/null 1>/dev/null
+      if [ $? -gt 0 ]
+      then
+        echo "true" > $DATADIR/reboot_required
+      else
+        echo "false" > $DATADIR/reboot_required
+      fi
+      /usr/bin/needs-restarting 2>/dev/null | sed 's/[[:space:]]*$//' >$DATADIR/apps_to_restart
     ;;
   esac
 else


### PR DESCRIPTION
[Generated using mergeup script](https://github.com/puppetlabs/pe-dev-scripts/blob/master/workflow/mergeup.sh)

* 2019.8.x:
  (PE-33536) Pick correct field in versionlock file
  (PE-33536) Improve handling of yum history info output
  (PE-33536) Ignore comment lines in versionlock file
  (PE-33536) Add support for Amazon Linux 2