### PR TITLE
(PE-35460) Remove use of legacy fact

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -462,7 +462,7 @@ class pe_patch (
         scheduled_task { 'pe_patch fact generation':
           ensure    => $ensure,
           enabled   => true,
-          command   => "${::system32}/WindowsPowerShell/v1.0/powershell.exe",
+          command   => "${facts['os']['windows']['system32']}/WindowsPowerShell/v1.0/powershell.exe",
           arguments => "-NonInteractive -ExecutionPolicy RemoteSigned -File ${fact_cmd}",
           user      => 'SYSTEM',
           trigger   => [


### PR DESCRIPTION
Because Puppet 8 will remove legacy facts, this replaces the use of the system32 legacy fact with the full path to the real fact so the module will work with Puppet 8.