### PR TITLE
(maint) Change run_puppet max_timeout param to timeout_seconds

### DIFF
--- a/plans/group_patching.pp
+++ b/plans/group_patching.pp
@@ -52,7 +52,7 @@ plan pe_patch::group_patching (
         $patch_ready = []
       } else {
         $pre_patch_run_puppet_check = run_task('enterprise_tasks::run_puppet', $puppet_healthy,
-          max_timeout     => 256,
+          timeout_seconds => 300,
           '_catch_errors' => true)
         $patch_ready = $pre_patch_run_puppet_check.ok_set.names
         $pre_patch_puppet_run_failed = $pre_patch_run_puppet_check.error_set.names
@@ -178,7 +178,7 @@ plan pe_patch::group_patching (
       # Sometimes a puppet run immediately after reboot fails, so give it a bit of time.
       pe_patch::sleep(30)
       $post_puppet_check = run_task('enterprise_tasks::run_puppet', $post_patch_ready,
-        max_timeout     => 256,
+        timeout_seconds => 300,
         '_catch_errors' => true)
       $post_patch_puppet_run_passed = $post_puppet_check.ok_set.names
       $post_patch_puppet_run_failed = $post_puppet_check.error_set.names


### PR DESCRIPTION
In the next versions of PE, this parameter will change from max_timeout to timeout_seconds.