### PR TITLE
Phase out egrep since it triggers warnings on grep version >= 3.8

### DIFF
--- a/templates/pe_patch_fact_generation.sh.epp
+++ b/templates/pe_patch_fact_generation.sh.epp
@@ -26,9 +26,9 @@ case $(facter osfamily) in
     # ---
     # We need to filter those out as they screw up the package listing, in addition
     # to other messages.
-    PKGS=$(yum -q check-update 2>/dev/null | egrep -v "^Security:|is broken|^Loaded plugins|^You should report|^To help pinpoint" | awk '/^[[:alnum:]]/ {print $1}')
+    PKGS=$(yum -q check-update 2>/dev/null | grep -E -v "^Security:|is broken|^Loaded plugins|^You should report|^To help pinpoint" | awk '/^[[:alnum:]]/ {print $1}')
     PKGS=$(echo $PKGS | sed 's/Obsoleting.*//')
-    SECPKGS=$(yum -q --security check-update 2>/dev/null | egrep -v "^Security:|is broken|^Loaded plugins|^You should report|^To help pinpoint" | awk '/^[[:alnum:]]/ {print $1}')
+    SECPKGS=$(yum -q --security check-update 2>/dev/null | grep -E -v "^Security:|is broken|^Loaded plugins|^You should report|^To help pinpoint" | awk '/^[[:alnum:]]/ {print $1}')
     SECPKGS=$(echo $SECPKGS | sed 's/Obsoleting.*//')
     HELDPKGS=$([ -r /etc/yum/pluginconf.d/versionlock.list ] && sed 's/^#.*//' /etc/yum/pluginconf.d/versionlock.list | awk -F':' '/:/ {if ($1 ~ /^[0-9]/) {print $2} else {print $1}}' | sed 's/-[0-9].*//')
   ;;
@@ -99,7 +99,7 @@ cat /dev/null > ${MISMATCHHELDPKGFILE}
 cat /dev/null > ${CATHELDPKGFILE}
 for CATHELD in $VERSION_LOCK_FROM_CATALOG
 do
-  if [ $(egrep -c "^${CATHELD}$" ${OSHELDPKGFILE}) -eq 0 ]
+  if [ $(grep -E -c "^${CATHELD}$" ${OSHELDPKGFILE}) -eq 0 ]
 	then
 		echo "$CATHELD" >> ${MISMATCHHELDPKGFILE}
 	fi


### PR DESCRIPTION
On Fedora 38 (and any version of grep >= 3.8), using `egrep` produces output:

```
egrep: warning: egrep is obsolescent; using grep -E
```

which creates extra noise in our environment. This patch will clean that up.

