### PR TITLE
(PE-34863) Catch errors in last_boot_time

### DIFF
--- a/plans/group_patching.pp
+++ b/plans/group_patching.pp
@@ -68,7 +68,7 @@ plan pe_patch::group_patching (
     } else {
       # So we can detect when a node has rebooted
       $begin_boot_time_results = without_default_logging() || {
-        run_task('pe_patch::last_boot_time', $patch_ready)
+        run_task('pe_patch::last_boot_time', $patch_ready, '_catch_errors' => true)
       }
 
       $begin_boot_time_target_info = Hash($begin_boot_time_results.results.map |$item| {


### PR DESCRIPTION
If you are running the plan with run_health_check set to false, then if any node is not reachable, the entire plan will fail due to not catching the error coming from running the last_boot_time task. This catches that error, so the nodes that fail this are removed from the list for the next step, but the plan can proceed to patch the rest of the nodes.