### PR TITLE
Pull environment from puppet.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -249,7 +249,7 @@ class pe_patch (
         file { $fact_cmd:
           ensure  => $ensure_file,
           mode    => $fact_mode,
-          content => epp("${module_name}/${fact_file}.epp", {'environment' => $environment}),
+          content => epp("${module_name}/${fact_file}.epp", {}),
           notify  => Exec[$fact_exec],
         }
       }
@@ -257,7 +257,7 @@ class pe_patch (
         file { $fact_cmd:
           ensure  => $ensure_file,
           mode    => $fact_mode,
-          content => epp("${module_name}/${fact_file}.epp", {'windows_puppet_installpath' => $windows_puppet_install_path, 'windows_update_criteria' => $windows_update_criteria, 'environment' => $environment}),
+          content => epp("${module_name}/${fact_file}.epp", {'windows_puppet_installpath' => $windows_puppet_install_path, 'windows_update_criteria' => $windows_update_criteria}),
           notify  => Exec[$fact_exec],
         }
 

--- a/templates/pe_patch_fact_generation.ps1.epp
+++ b/templates/pe_patch_fact_generation.ps1.epp
@@ -336,7 +336,8 @@ function Invoke-RefreshPuppetFacts {
     if ($diff) {
         Add-LogEntry "Uploading puppet facts"
         $puppetCmd = Join-Path "<%= $windows_puppet_installpath %>" -ChildPath "\bin\puppet.bat"
-        & $puppetCmd facts upload --environment="<%= $environment %>" --color=false
+        $puppetEnv = & $puppetCmd config print environment --section agent
+        & $puppetCmd facts upload --environment $puppetEnv --color=false
     }
 }
 

--- a/templates/pe_patch_fact_generation.sh.epp
+++ b/templates/pe_patch_fact_generation.sh.epp
@@ -156,7 +156,7 @@ rm -f "${UPDATEFILE}.previous"
 if [ "${diff}" != "0" ]
 then
   logger -p info -t pe_patch_fact_generation.sh "Uploading facts"
-  puppet facts upload --environment "<%= $environment %>" 2>/dev/null 1>/dev/null
+  puppet facts upload --environment $(puppet config print environment --section agent) 2>/dev/null 1>/dev/null
 fi
 logger -p info -t pe_patch_fact_generation.sh "Patch data refreshed"
 


### PR DESCRIPTION
Rather than using whatever environment we're currently running in, this updates the pe_patch fact update script to pull the configured environment from puppet.conf. As a result, one-time runs using the `--environment` command-line parameter (or the orchestrator via PXP) no longer show gratuitous changes on this file.