### PR TITLE
Ignore packages with versions if they have a provider of puppet.*gem

### DIFF
--- a/templates/pe_patch_fact_generation.sh.epp
+++ b/templates/pe_patch_fact_generation.sh.epp
@@ -58,7 +58,7 @@ CATALOG="$(puppet config print vardir)/client_data/catalog/$(puppet config print
 
 if [ -f "${CATALOG}" ]
 then
-	VERSION_LOCK_FROM_CATALOG=$(cat $CATALOG | /opt/puppetlabs/puppet/bin/ruby -e "require 'json'; begin; json_hash = JSON.parse(ARGF.read); json_hash['resources'].select { |r| r['type'] == 'Package' and r['parameters'] and r['parameters']['ensure'] and r['parameters']['ensure'].match /\d.+/ }.each do | m | puts m['title'] end; rescue; puts ''; end")
+	VERSION_LOCK_FROM_CATALOG=$(cat $CATALOG | /opt/puppetlabs/puppet/bin/ruby -e "require 'json'; begin; json_hash = JSON.parse(ARGF.read); json_hash['resources'].select { |r| r['type'] == 'Package' and r['parameters'] and r['parameters']['ensure'] and r['parameters']['ensure'].match /\d.+/ and r['parameters']['provider'] !~ /puppet.*gem/ }.each do | m | puts m['title'] end; rescue; puts ''; end")
 else
 	VERSION_LOCK_FROM_CATALOG=''
 fi


### PR DESCRIPTION
I found the `toml_rb` gem was being picked up as a package with a version that wasn't locked at the OS layer.  Since it's a gem and not part of the OS level patching, this PR removes any package with the provider of `puppet.*gem` from showing up.