### PR TITLE
(PE-4000) Add package_list parameter to patch_server task

### DIFF
--- a/tasks/patch_server.json
+++ b/tasks/patch_server.json
@@ -28,6 +28,10 @@
     "clean_cache": {
       "description": "Should the yum/dpkg caches be cleaned at the start of the task? (Defaults to false)",
       "type": "Optional[Boolean]"
+    },
+    "package_list": {
+      "description": "List of packages to update or Windows updates to install (Defaults to all available updates, ignored if security_only=true)",
+      "type": "Optional[Array[String]]"
     }
   },
   "implementations": [

--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -580,7 +580,7 @@ end
 
 # Run the patching
 if facts['values']['os']['family'] == 'RedHat'
-  if !securityFlag.empty? || package_list_param.empty?
+  if !securityflag.empty? || package_list_param.empty?
     log.info 'Running yum upgrade'
     log.debug "Timeout value set to : #{timeout}"
     yum_end = ''

--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -452,25 +452,25 @@ if params['package_list'] && security_only == false
   #   - For Windows, each KB article ID must be a number and must exist in missing_update_kbs.
   #   - For Linux, each package must exist in package_updates. Note that on RedHat package_updates
   #     entries include architecture (e.g. 'foo-libs.x86_64') so factor this into the check.
-  if facts['values']['os']['family'] == 'windows'
-    missing_update_kbs = facts['values']['pe_patch']['missing_update_kbs']
+  if facts.dig('values', 'os', 'family') == 'windows'
+    missing_update_kbs = facts.dig ('values', 'pe_patch', 'missing_update_kbs')
     params['package_list'].each do |kb_article_id|
-      if kb_article_id.to_i == 0
+      if kb_article_id.to_i.to_s != kb_article_id
         err('107', 'pe_patch/package_list', 'KB ID is not a number: ' + kb_article_id, starttime)
       end
       if !missing_update_kbs.include?("KB#{kb_article_id}")
         err('107', 'pe_patch/package_list', 'No missing KB with ID: ' + kb_article_id, starttime)
       end
     end
-  elsif facts['values']['os']['family'] == 'RedHat'
-    package_updates = facts['values']['pe_patch']['package_updates']
+  elsif facts.dig('values', 'os', 'family') == 'RedHat'
+    package_updates = facts.dig('values', 'pe_patch', 'package_updates')
     params['package_list'].each do |pkg|
       if !package_updates.any? { |update| update.start_with?("#{pkg}.") }
         err('107', 'pe_patch/package_list', 'No update available for package: ' + pkg, starttime)
       end
     end
   else
-    package_updates = facts['values']['pe_patch']['package_updates']
+    package_updates = facts.dig('values', 'pe_patch', 'package_updates')
     params['package_list'].each do |pkg|
       if !package_updates.include?(pkg)
         err('107', 'pe_patch/package_list', 'No update available for package: ' + pkg, starttime)
@@ -548,7 +548,7 @@ if security_only == true
   securityflag = '--security'
 else
   if package_list_param.empty?
-    updatecount = facts['values']['pe_patch']['package_update_count']
+    updatecount = facts.dig('values', 'pe_patch', 'package_update_count')
   else
     updatecount = package_list_param.length
   end

--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -548,7 +548,7 @@ if security_only == true
   securityflag = '--security'
 else
   if package_list_param.empty?
-    updatecount = facts.dig('values', 'pe_patch', 'package_update_count')
+    updatecount = facts['values']['pe_patch']['package_update_count']
   else
     updatecount = package_list_param.length
   end

--- a/templates/pe_patch_groups.ps1.epp
+++ b/templates/pe_patch_groups.ps1.epp
@@ -36,7 +36,10 @@ Switch, when set the script will only install updates with a category that inclu
 Criteria used for update detection. This ultimately drives which updates will be installed. The default for this script is determined by pe_patch::windows_update_criteria, and is "IsInstalled=0 and IsHidden=0 and Type='Software'" unless otherwise specified, which should be suitable in most cases, and relies on your upstream update approvals. Note that this is not validated, if the syntax is not validated the script will fail. See MSDN docs for valid syntax - https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdatesearcher-search
 
 .PARAMETER MaxUpdates
-Install only the first X numbmer of updates (at most). Useful ror testing.
+Install only the first X numbmer of updates (at most). Useful for testing.
+
+.PARAMETER KB
+Comma separated list of KB(s) to install. Useful for installing a specific update, or a small number of updates. Ignored if SecurityOnly=true.
 #>
 
 
@@ -100,6 +103,12 @@ param(
     [Parameter(ParameterSetName = "InstallUpdates-ForceSchedTask")]
     [Parameter(ParameterSetName = "InstallUpdates")]
     [Int32]$MaxUpdates,
+
+    # only install updates related to this KB
+    [Parameter(ParameterSetName = "InstallUpdates-Forcelocal")]
+    [Parameter(ParameterSetName = "InstallUpdates-ForceSchedTask")]
+    [Parameter(ParameterSetName = "InstallUpdates")]
+    [String]$KB,
 
     # path to lock file
     [String]$LockFile = "$($env:programdata)\PuppetLabs\pe_patch\pe_patch_groups.lock",
@@ -626,7 +635,15 @@ $scriptBlock = {
             $updatesToInstall = Get-SecurityUpdates -Updates $allUpdates
         }
         else {
-            $updatesToInstall = $allUpdates
+            if ($Params.KB) {
+                Add-LogEntry "Installing all updates relating to $($Params.KB)"
+                $kbs = $Params.KB -split ","
+                $updatesToInstall = $allUpdates | Where-Object { $kbs -contains $_.KBArticleIDs }
+            }
+            else {
+                Add-LogEntry "Installing all updates"
+                $updatesToInstall = $allUpdates
+            }
         }
 
         # filter to maxupdates if required
@@ -856,6 +873,7 @@ try {
         DebugPreference   = $DebugPreference
         VerbosePreference = $VerbosePreference
         LogFile           = $LogFile
+        KB                = $KB
     }
 
     # see if WU API is available (e.g. running in a local session)


### PR DESCRIPTION
### Change
Adding new `package_list` parameter to the `patch_server` task which accepts an `Array[String]` of package names or Windows KBs to be installed.
- If `package_list` is not provided behaviour is as before, all available package updates (or KBs) are installed.
- If `security_only=true` is provided then behaviour is also as before, all available security related package updates (or KBs) are installed.
- If `package_list=["...","..."]` & `security_only=true` are both provided then `package_list` is ignored and all available security related package updates (or KBs) are installed.

Validation is performed on `package_list` to ensure each package/KB is present in `package_updates` or `missing_update_kbs` respectively. This will ensure the task fails early with a consistent error across platforms, rather than waiting on the package manager (or Windows update) to fail.

### Testing
Manual testing performed by building the module and installing it on PE, then running the `patch_server` task to install patches on:

* RHEL8 node with `package_list: ["python3-perf"]`
```
{
  "pinned_packages" : [ ],
  "security" : false,
  "return" : "Success",
  "start_time" : "2025-01-23T09:31:57+00:00",
  "debug" : "Last metadata expiration check: 0:08:44 ago on Thu Jan 23 09:23:40 2025.\nDependencies resolved.\n=============================================================================================\n Package        Arch    Version                Repository                                Size\n=============================================================================================\nUpgrading:\n python3-perf   x86_64  4.18.0-553.36.1.el8_10 rhui-rhel-8-for-x86_64-baseos-rhui-rpms   11 M\n\nTransaction Summary\n=============================================================================================\nUpgrade  1 Package\n\nTotal download size: 11 M\nDownloading Packages:\npython3-perf-4.18.0-553.36.1.el8_10.x86_64.rpm   19 MB/s |  11 MB     00:00    \n--------------------------------------------------------------------------------\nTotal                                            14 MB/s |  11 MB     00:00     \nRunning transaction check\nTransaction check succeeded.\nRunning transaction test\nTransaction test succeeded.\nRunning transaction\n  Preparing        :                                                        1/1 \n  Upgrading        : python3-perf-4.18.0-553.36.1.el8_10.x86_64             1/2 \n  Cleanup          : python3-perf-4.18.0-553.34.1.el8_10.x86_64             2/2 \n  Running scriptlet: python3-perf-4.18.0-553.34.1.el8_10.x86_64             2/2 \n  Verifying        : python3-perf-4.18.0-553.36.1.el8_10.x86_64             1/2 \n  Verifying        : python3-perf-4.18.0-553.34.1.el8_10.x86_64             2/2 \n\nUpgraded:\n  python3-perf-4.18.0-553.36.1.el8_10.x86_64                                    \n\nComplete!\n",
  "end_time" : "2025-01-23T09:33:09+00:00",
  "was_rebooted" : false,
  "reboot" : "never",
  "packages_updated" : {
    "python3-perf-4.18.0-553.34.1.el8_10.x86_64" : "Upgraded"
  },
  "job_id" : "32",
  "message" : "Patching complete"
}
```
* Ubuntu 20.04 node with `package_list: ["vim","vim-tiny","vim-runtime","vim-common"]`
```
{
  "pinned_packages" : [ ],
  "security" : false,
  "return" : "Success",
  "start_time" : "2025-01-23T11:14:56+00:00",
  "debug" : "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSuggested packages:\n  ctags vim-doc vim-scripts indent\nThe following packages will be upgraded:\n  vim vim-common vim-runtime vim-tiny\n4 upgraded, 0 newly installed, 0 to remove and 8 not upgraded.\nNeed to get 7782 kB of archives.\nAfter this operation, 0 B of additional disk space will be used.\nGet:1 http://us-west1.gce.archive.ubuntu.com/ubuntu focal-updates/main amd64 vim amd64 2:8.1.2269-1ubuntu5.30 [1242 kB]\nGet:2 http://us-west1.gce.archive.ubuntu.com/ubuntu focal-updates/main amd64 vim-tiny amd64 2:8.1.2269-1ubuntu5.30 [580 kB]\nGet:3 http://us-west1.gce.archive.ubuntu.com/ubuntu focal-updates/main amd64 vim-runtime all 2:8.1.2269-1ubuntu5.30 [5875 kB]\nGet:4 http://us-west1.gce.archive.ubuntu.com/ubuntu focal-updates/main amd64 vim-common all 2:8.1.2269-1ubuntu5.30 [85.4 kB]\nFetched 7782 kB in 1s (14.2 MB/s)\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 73098 files and directories currently installed.)\r\nPreparing to unpack .../vim_2%3a8.1.2269-1ubuntu5.30_amd64.deb ...\r\nUnpacking vim (2:8.1.2269-1ubuntu5.30) over (2:8.1.2269-1ubuntu5.29) ...\r\nPreparing to unpack .../vim-tiny_2%3a8.1.2269-1ubuntu5.30_amd64.deb ...\r\nUnpacking vim-tiny (2:8.1.2269-1ubuntu5.30) over (2:8.1.2269-1ubuntu5.29) ...\r\nPreparing to unpack .../vim-runtime_2%3a8.1.2269-1ubuntu5.30_all.deb ...\r\nUnpacking vim-runtime (2:8.1.2269-1ubuntu5.30) over (2:8.1.2269-1ubuntu5.29) ...\r\nPreparing to unpack .../vim-common_2%3a8.1.2269-1ubuntu5.30_all.deb ...\r\nUnpacking vim-common (2:8.1.2269-1ubuntu5.30) over (2:8.1.2269-1ubuntu5.29) ...\r\nSetting up vim-common (2:8.1.2269-1ubuntu5.30) ...\r\nSetting up vim-runtime (2:8.1.2269-1ubuntu5.30) ...\r\nSetting up vim (2:8.1.2269-1ubuntu5.30) ...\r\nSetting up vim-tiny (2:8.1.2269-1ubuntu5.30) ...\r\nProcessing triggers for mime-support (3.64ubuntu1) ...\r\nProcessing triggers for man-db (2.9.1-1) ...\r\n",
  "end_time" : "2025-01-23T11:15:56+00:00",
  "was_rebooted" : false,
  "reboot" : "never",
  "packages_updated" : [ "vim", "vim-tiny", "vim-runtime", "vim-common" ],
  "job_id" : "",
  "message" : "Patching complete"
}
```
* SLES12 node with `package_list: ["python3-PyYAML","python3-requests","python3-six"]`
```
{
  "pinned_packages" : [ "plymouth*" ],
  "security" : false,
  "return" : "Success",
  "start_time" : "2025-01-23T11:36:02+00:00",
  "debug" : "\nThe following 11 items are locked and will not be changed by any action:\n Available:\n  plymouth plymouth-branding-SLE plymouth-devel plymouth-dracut plymouth-plugin-label plymouth-plugin-label-ft plymouth-plugin-script plymouth-plugin-tribar plymouth-scripts plymouth-theme-tribar plymouth-x11-renderer\n\nThe following NEW package is going to be installed:\n  python3-PySocks\n\nThe following 3 packages are going to be upgraded:\n  python3-PyYAML python3-requests python3-six\n\n3 packages to upgrade, 1 new.\n\nPackage download size:   391.0 KiB\n\nPackage install size change:\n              |       1.4 MiB  required by to be installed packages\n   226.9 KiB  |  -    1.2 MiB  released by to be removed packages  \nContinue? [y/n/...? shows all options] (y): y\n",
  "end_time" : "2025-01-23T11:36:32+00:00",
  "was_rebooted" : false,
  "reboot" : "never",
  "packages_updated" : [ "python3-PyYAML", "python3-requests", "python3-six" ],
  "job_id" : "",
  "message" : "Patching complete"
}
```
* Windows 2019 node with `package_list: ["5050008"]`
```
{
  "pinned_packages" : "",
  "security" : false,
  "return" : "Success",
  "start_time" : "2025-01-28T13:46:48+00:00",
  "debug" : [ "pe_patch_groups: started", "Timeout of 3600 seconds provided. Calculated target end time of update installation window as 01/28/2025 14:47:04", "True", "Running code as a local script block via Invoke-Command", "Performing update search with criteria: IsInstalled=0 and IsHidden=0 and Type='Software'", "Detected 1 updates are required in total (including security):", "  - 2025-01 Cumulative Update for Windows Server 2019 (1809) for x64-based Systems (KB5050008)", "Installing all updates", "All updates are already downloaded", "Installing 1 updates", "Installing update 1/1: 2025-01 Cumulative Update for Windows Server 2019 (1809) for x64-based Systems (KB5050008)", "##Output File is C:\\Windows\\TEMP\\pe_patch-results_2025_01_28-13_47_17.json", "Performing update search with criteria: IsInstalled=0 and IsHidden=0 and Type='Software'", "Detected 1 updates are required in total (including security):", "  - 2025-01 Cumulative Update for Windows Server 2019 (1809) for x64-based Systems (KB5050008)", "Installing all updates", "All updates are already downloaded", "Installing 1 updates", "Installing update 1/1: 2025-01 Cumulative Update for Windows Server 2019 (1809) for x64-based Systems (KB5050008)", "##Output File is C:\\Windows\\TEMP\\pe_patch-results_2025_01_28-13_47_17.json", "pe_patch_groups: finished" ],
  "end_time" : "2025-01-28T13:47:18+00:00",
  "was_rebooted" : false,
  "reboot" : "never",
  "packages_updated" : [ "2025-01 Cumulative Update for Windows Server 2019 (1809) for x64-based Systems (KB5050008)" ],
  "job_id" : "",
  "message" : "Patching complete"
}
```