### PR TITLE
(PE-40097) Add tag for only pe_patch changes to be applied

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -160,6 +160,9 @@ class pe_patch (
   Enum['present', 'absent'] $ensure  = 'present',
 ) {
 
+  # ensure that the tag will not collide with other top-level tags
+  tag('pe_patch_only-1fc83547-6b51-499f-98cd-58e25b2288c7')
+
   if defined(Class['os_patching']) {
     notify { 'os_patching warning':
       message => 'This node currently has the os_patching class applied. In order to use pe_patch, please remove os_patching from this node first. The pe_patch class will not be applied on this puppet run.',


### PR DESCRIPTION
This adds a tag to the module so that the orchestrator can specify a tag for only the pe_patch class to be applied.