### PR TITLE
(maint) Remove space in dig call

### DIFF
--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -453,7 +453,7 @@ if params['package_list'] && security_only == false
   #   - For Linux, each package must exist in package_updates. Note that on RedHat package_updates
   #     entries include architecture (e.g. 'foo-libs.x86_64') so factor this into the check.
   if facts.dig('values', 'os', 'family') == 'windows'
-    missing_update_kbs = facts.dig ('values', 'pe_patch', 'missing_update_kbs')
+    missing_update_kbs = facts.dig('values', 'pe_patch', 'missing_update_kbs')
     params['package_list'].each do |kb_article_id|
       if kb_article_id.to_i.to_s != kb_article_id
         err('107', 'pe_patch/package_list', 'KB ID is not a number: ' + kb_article_id, starttime)


### PR DESCRIPTION
Removing an errant space that's causing an error on Windows
```
Error: Exited 1:
/opt/puppetlabs/pxp-agent/tasks-cache/ea4ae2069119e22707beb26f92196e836c30f4d0f9a54145d660ef4eb1ca5e1d/patch_server.rb: --> /opt/puppetlabs/pxp-agent/tasks-cache/ea4ae2069119e22707beb26f92196e836c30f4d0f9a54145d660ef4eb1ca5e1d/patch_server.rb
syntax error, unexpected ',', expecting ')'
  438  if params['package_list'] && security_only == false
> 455    if facts.dig('values', 'os', 'family') == 'windows'
> 456      missing_update_kbs = facts.dig ('values', 'pe_patch', 'missing_update_kbs')
> 465    elsif facts.dig('values', 'os', 'family') == 'RedHat'
> 466      package_updates = facts.dig('values', 'pe_patch', 'package_updates')
> 472    else
> 479    end
  483  end
/opt/puppetlabs/pxp-agent/tasks-cache/ea4ae2069119e22707beb26f92196e836c30f4d0f9a54145d660ef4eb1ca5e1d/patch_server.rb:456: syntax error, unexpected ',', expecting ')' (SyntaxError)
...date_kbs = facts.dig ('values', 'pe_patch', 'missing_update_...
```