### PR TITLE
Fixed issues on SLES where needs restarting is more verbose

### DIFF
--- a/templates/pe_patch_fact_generation.sh.epp
+++ b/templates/pe_patch_fact_generation.sh.epp
@@ -132,7 +132,7 @@ then
       else
         echo "false" > $DATADIR/reboot_required
       fi
-      /usr/bin/needs-restarting 2>/dev/null | grep -v '^Updating Subscription' | sed 's/[[:space:]]*$//' >$DATADIR/apps_to_restart
+      /usr/bin/needs-restarting 2>/dev/null | grep -Ev "^$|^Updating Subscription|No processes|No core lib|not necessary" | sed 's/[[:space:]]*$//' >$DATADIR/apps_to_restart
     ;;
   esac
 else


### PR DESCRIPTION
```bash
suse-15-puppet-dev-1:~ # needs-restarting
No processes using deleted files found.

No core libraries or services have been updated since the last system boot.
Reboot is probably not necessary.
```

without the fix we get this in the `fact`

```
suse-15-puppet-dev-1:~ # facter -p pe_patch.reboots
{
  app_restart_required => true,
  apps_needing_restart => {
     => null,
    No core libraries or services have been updated since the last system boot. => null,
    No processes using deleted files found. => null,
    Reboot is probably not necessary. => null
  },
  reboot_required => false
}
```